### PR TITLE
Add hook to allow filtration of customer email

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -105,6 +105,8 @@ class EDD_HS_Endpoint {
 			$emails = array( $customer_data['email'] );
 		}
 
+		$emails = apply_filters( 'helpscout_edd_customer_emails', $emails, $this->data );
+
 		if( count( $emails ) === 0 ) {
 			$this->respond( 'No customer email given.' );
 		}


### PR DESCRIPTION
As it stands this integration depends on the email address used being the same as an EDD customer. In my case I find that to happen about half the time; there's a good chance the license was purchased on behalf of a client and the email address for the ticket is that of the developer. That results in a lot of false positive 'No purchase data found' messages.

As a workaround I've implemented something on my end that generates a nonce in the subject line that matches the license so I can reverse look up the actual license holder email, but in order for it to work I need to be able to filter what `edd-helpscout` uses as the customer email address. This little hook gets that done.