### PR TITLE
Use new PayPal Transaction URL

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -353,7 +353,7 @@ class Endpoint {
 				foreach ( $notes as $note ) {
 					if ( preg_match( '/^PayPal Transaction ID: ([^\s]+)/', $note->comment_content, $match ) ) {
 						$transaction_id = $match[1];
-						$payment_method = '<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id=' . esc_attr( $transaction_id ) . '" target="_blank">PayPal</a>';
+						$payment_method = '<a href="https://www.paypal.com/us/vst/id=' . esc_attr( $transaction_id ) . '" target="_blank">PayPal</a>';
 						break 2;
 					}
 				}


### PR DESCRIPTION
The old format kicks you out of the new PayPal design, then you have to opt back in. Also, if not signed in, it doesn't properly redirect after login.

Use new PayPal transaction URL format:

`https://www.paypal.com/us/vst/id={Transaction ID}`

Instead of old format:

`https://www.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id={Transaction ID}`