### PR TITLE
fix PHP notices about missing variables / indexes

### DIFF
--- a/views/order-row.php
+++ b/views/order-row.php
@@ -35,13 +35,15 @@
 		</p>
 
 		<?php if ( ! empty( $order['downloads'] ) ) : ?>
-			<?php do_action( 'edd_helpscout_before_order_downloads', $order, $downloads ); ?>
+			<?php do_action( 'edd_helpscout_before_order_downloads', $order, $order['downloads'] ); ?>
 
 			<ul class="unstyled">
 				<?php foreach( $order['downloads'] as $download ) : ?>
 					<li>
-						<strong><?php echo get_the_title( $download['id'] ); ?></strong><br />
-						<?php echo edd_get_price_option_name( $download['id'], $download['options']['price_id'] ); ?>
+						<?php if (isset($download['id'])): // this is the actual download ?>
+							<strong><?php echo get_the_title( $download['id'] ); ?></strong><br />
+							<?php echo edd_get_price_option_name( $download['id'], $download['options']['price_id'] ); ?>
+						<?php endif ?>
 
 						<?php do_action( 'edd_helpscout_before_order_download_details', $order, $download ); ?>
 
@@ -90,7 +92,7 @@
 				<?php endforeach; ?>
 			</ul>
 
-			<?php do_action( 'edd_helpscout_after_order_downloads', $order, $downloads ); ?>
+			<?php do_action( 'edd_helpscout_after_order_downloads', $order, $order['downloads'] ); ?>
 
 		<?php endif; // endif downloads ?>
 


### PR DESCRIPTION
Not sure about the use of the second parameter of `edd_helpscout_before_order_downloads` and `edd_helpscout_after_order_downloads` since downloads is contained in order anyway, but I left it like this in case anyone actually used it (was broken though?)